### PR TITLE
FIX: Link to right directory in conda

### DIFF
--- a/binder/appendix.txt
+++ b/binder/appendix.txt
@@ -7,8 +7,7 @@ RUN apt update && \
     rm -rf /tmp/lrose.deb
 
 USER ${NB_USER}
-RUN CONDA_DIR=/srv/conda && \
-    RADARENV=erad-2024-dev && \
+RUN RADARENV=erad-2024-dev && \
     CONDA_PREFIX=$CONDA_DIR/envs/$RADARENV && \
     export PROJ_NETWORK=ON && \
     export BALTRAD_INSTALL_ROOT=${PWD} && \

--- a/binder/appendix.txt
+++ b/binder/appendix.txt
@@ -16,7 +16,6 @@ RUN CONDA_DIR=/srv/conda && \
     echo "export RADARENV=$RADARENV" >> ~/.profile && \
     echo "export CONDA_PREFIX=$CONDA_PREFIX" >> ~/.profile && \
     echo "export PROJ_NETWORK=$PROJ_NETWORK" >> ~/.profile && \
-    ls ${CONDA_PREFIX}/bin/ && \
     ${CONDA_PREFIX}/bin/bash -l $BALTRAD_INSTALL_ROOT/install/baltrad/install_baltrad.sh && \
     ${CONDA_PREFIX}/bin/bash -l $BALTRAD_INSTALL_ROOT/install/nbstripout_notebooks.sh && \
     cp binder/kernel.json $CONDA_PREFIX/share/jupyter/kernels/python3/.


### PR DESCRIPTION
Link to the proper directory for BALTRAD