### PR TITLE
FIX: Stop using latest in docker file

### DIFF
--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/openradar/erad2024:latest
+FROM ghcr.io/openradar/erad2024:d6ee5b14f782


### PR DESCRIPTION
Stop using the latest tag in the docker file