### PR TITLE
FIX: use additional tag on push

### DIFF
--- a/.github/workflows/build-book-pullrequest.yaml
+++ b/.github/workflows/build-book-pullrequest.yaml
@@ -27,6 +27,9 @@ on:
 permissions:
   contents: read
 
+env:
+  DOCKER_TAG: pr_68
+
 jobs:
   build-book:
     runs-on: ubuntu-latest
@@ -59,6 +62,7 @@ jobs:
           DOCKER_USERNAME: "openradar"
           DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_REGISTRY: "ghcr.io"
+          ADDITIONAL_TAG: ${{ env.DOCKER_TAG }}
           PUBLIC_REGISTRY_CHECK: true
           APPENDIX_FILE: "binder/appendix.txt"
           REPO2DOCKER_EXTRA_ARGS: --Repo2Docker.base_image=docker.io/library/buildpack-deps:jammy

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -23,8 +23,9 @@ on:
         required: false
         default: 'true'
         type: string  # had a lot of trouble with boolean types, see https://github.com/actions/runner/issues/1483
+
 env:
-  DOCKER_TAG: pr
+  DOCKER_TAG: pr_68
 
 jobs:
   build-container:
@@ -54,7 +55,7 @@ jobs:
           DOCKER_USERNAME: "openradar"
           DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_REGISTRY: "ghcr.io"
-          ADDITIONAL_TAG: "pr"
+          ADDITIONAL_TAG: ${{ env.DOCKER_TAG }}
           PUBLIC_REGISTRY_CHECK: true
           APPENDIX_FILE: "binder/appendix.txt"
           REPO2DOCKER_EXTRA_ARGS: --Repo2Docker.base_image=docker.io/library/buildpack-deps:jammy

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -23,6 +23,8 @@ on:
         required: false
         default: 'true'
         type: string  # had a lot of trouble with boolean types, see https://github.com/actions/runner/issues/1483
+env:
+  DOCKER_TAG: pr
 
 jobs:
   build-container:
@@ -52,6 +54,7 @@ jobs:
           DOCKER_USERNAME: "openradar"
           DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_REGISTRY: "ghcr.io"
+          ADDITIONAL_TAG: "pr"
           PUBLIC_REGISTRY_CHECK: true
           APPENDIX_FILE: "binder/appendix.txt"
           REPO2DOCKER_EXTRA_ARGS: --Repo2Docker.base_image=docker.io/library/buildpack-deps:jammy

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/openradar/erad2024:d6ee5b14f782
+FROM ghcr.io/openradar/erad2024:pr_68


### PR DESCRIPTION
@openradar/erad2024-team 

To keep the pythia-binder up to date, we need to tag the build image with some new tag and use this tag in the `binder/Dockerfile`. To be on the safe side, we can apply a tag which corresponds to the PR number.

