### PR TITLE
ADD: add gpm-api in appendix.txt (needs `--no-update-deps`)

### DIFF
--- a/.github/workflows/build-book-pullrequest.yaml
+++ b/.github/workflows/build-book-pullrequest.yaml
@@ -28,7 +28,7 @@ permissions:
   contents: read
 
 env:
-  DOCKER_TAG: pr_71
+  DOCKER_TAG: pr_75
 
 jobs:
   build-book:

--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -25,7 +25,7 @@ on:
         type: string  # had a lot of trouble with boolean types, see https://github.com/actions/runner/issues/1483
 
 env:
-  DOCKER_TAG: pr_71
+  DOCKER_TAG: pr_75
 
 jobs:
   build-container:

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/openradar/erad2024:pr_71
+FROM ghcr.io/openradar/erad2024:pr_75

--- a/binder/appendix.txt
+++ b/binder/appendix.txt
@@ -19,6 +19,6 @@ RUN CONDA_DIR=/srv/conda && \
     echo "export PROJ_NETWORK=$PROJ_NETWORK" >> ~/.profile && \
     ${CONDA_PREFIX}/bin/bash -l $BALTRAD_INSTALL_ROOT/install/baltrad/install_baltrad.sh && \
     rm -rf $BALTRAD_INSTALL_ROOT/install && \
-    ${MAMBA_EXE} update -y -n $RADARENV gpm-api --no-update-deps && \
+    ${MAMBA_EXE} install -y -n $RADARENV gpm-api --no-update-deps && \
     ${MAMBA_EXE} clean --all -f -y && \
     cp binder/kernel.json $CONDA_PREFIX/share/jupyter/kernels/python3/.

--- a/binder/appendix.txt
+++ b/binder/appendix.txt
@@ -19,4 +19,6 @@ RUN CONDA_DIR=/srv/conda && \
     echo "export PROJ_NETWORK=$PROJ_NETWORK" >> ~/.profile && \
     ${CONDA_PREFIX}/bin/bash -l $BALTRAD_INSTALL_ROOT/install/baltrad/install_baltrad.sh && \
     rm -rf $BALTRAD_INSTALL_ROOT/install && \
+    ${MAMBA_EXE} update -y -n $RADARENV gpm-api --no-update-deps && \
+    ${MAMBA_EXE} clean --all -f -y && \
     cp binder/kernel.json $CONDA_PREFIX/share/jupyter/kernels/python3/.


### PR DESCRIPTION
A bit more context:

For #6 we need gpm-api. Unfortunately gpm_api is pinned to xarray <=2024.2.0, although it works quite well with that. I've added gpm-api within the `appendix.txt` to make use of it in the notebooks.

While doing this, I found it might be possible to create multiple environments also in `appendix.txt`. So if we encounter any clashes in the future this might be an option.